### PR TITLE
add 'provides' to resource as required by chef v16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ BD-NXLog Changelog
 =========================
 This file is used to list changes made in each version of the `bd_nxlog` cookbook.
 
+v0.1.4 (2021-05-06)
+-------------------
+### Fixes
+- add 'provides' in resource name for chef-client v16 compatibility
+
 v0.1.3 (2017-08-02)
 -------------------
 ### Fixes

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bd@bdwyertech.net'
 license 'Apache-2.0'
 description 'Installs/Configures bd_nxlog'
 long_description 'Installs/Configures bd_nxlog'
-version '0.1.3'
+version '0.1.4'
 
 issues_url 'https://github.com/bdwyertech/bd_nxlog/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/bdwyertech/bd_nxlog' if respond_to?(:source_url)

--- a/resources/nxlog_config.rb
+++ b/resources/nxlog_config.rb
@@ -19,6 +19,7 @@
 
 # => Define the Resource Name
 resource_name :nxlog_config
+provides :nxlog_config
 
 # => Define the Resource Properties
 property :config, String, name_property: true


### PR DESCRIPTION
https://docs.chef.io/release_notes_client/#breaking-change-in-resources
This would enable the cookbook to be used with chef-client version 16.